### PR TITLE
Update to workaround clean install issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "main": "dist/index.js",
   "dependencies": {
-    "@material-ui/core": "1.5.0",
+    "@babel/runtime": "7.0.0-beta.55",
+    "@material-ui/core": "1.4.3",
     "@material-ui/icons": "2.0.2",
     "ajv": "6.5.2",
     "classnames": "2.2.6",


### PR DESCRIPTION
Currently a fresh install on the repo doesn't work - this provides a functioning repo for this issue. https://github.com/creativetimofficial/material-kit-react/issues/32