### PR TITLE
Improved Carousel Integrity.

### DIFF
--- a/src/views/Components/Sections/SectionCarousel.jsx
+++ b/src/views/Components/Sections/SectionCarousel.jsx
@@ -28,6 +28,9 @@ class SectionCarousel extends React.Component {
     return (
       <div className={classes.section}>
         <div className={classes.container}>
+          <div className={classes.title}>
+            <h3>Carousel</h3>
+          </div>
           <GridContainer>
             <GridItem xs={12} sm={12} md={8} className={classes.marginAuto}>
               <Card carousel>

--- a/src/views/Components/Sections/SectionJavascript.jsx
+++ b/src/views/Components/Sections/SectionJavascript.jsx
@@ -328,9 +328,6 @@ class SectionJavascript extends React.Component {
               </Tooltip>
             </GridItem>
           </GridContainer>
-          <div className={classes.title}>
-            <h3>Carousel</h3>
-          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Previously, heading name for **Carousel** was declared in [SectionJavascript.jsx](https://github.com/creativetimofficial/material-kit-react/blob/master/src/views/Components/Sections/SectionJavascript.jsx) which makes this less component less modular, thus shifted to [SectionCarousel.jsx](https://github.com/creativetimofficial/material-kit-react/blob/master/src/views/Components/Sections/SectionCarousel.jsx).
```js
<div className={classes.title}>
  <h3>Carousel</h3>
</div>
```