### PR TITLE
Fixes typo where containerFluid was spelled conatinerFluid

### DIFF
--- a/src/assets/jss/material-kit-react.jsx
+++ b/src/assets/jss/material-kit-react.jsx
@@ -24,7 +24,7 @@ const transition = {
   transition: "all 0.33s cubic-bezier(0.685, 0.0473, 0.346, 1)"
 };
 
-const conatinerFluid = {
+const containerFluid = {
   paddingRight: "15px",
   paddingLeft: "15px",
   marginRight: "auto",
@@ -32,7 +32,7 @@ const conatinerFluid = {
   width: "100%"
 };
 const container = {
-  ...conatinerFluid,
+  ...containerFluid,
   "@media (min-width: 576px)": {
     maxWidth: "540px"
   },
@@ -184,7 +184,7 @@ export {
   drawerWidth,
   transition,
   container,
-  conatinerFluid,
+  containerFluid,
   boxShadow,
   card,
   defaultFont,

--- a/src/assets/jss/material-kit-react/views/componentsSections/exampleStyle.jsx
+++ b/src/assets/jss/material-kit-react/views/componentsSections/exampleStyle.jsx
@@ -1,4 +1,4 @@
-import { conatinerFluid } from "assets/jss/material-kit-react.jsx";
+import { containerFluid } from "assets/jss/material-kit-react.jsx";
 
 import imagesStyle from "assets/jss/material-kit-react/imagesStyles.jsx";
 
@@ -7,7 +7,7 @@ const exampleStyle = {
     padding: "70px 0"
   },
   container: {
-    ...conatinerFluid,
+    ...containerFluid,
     textAlign: "center !important"
   },
   ...imagesStyle,


### PR DESCRIPTION
One of the exported styles was named `conatinerFluid`.  This fixes that spelling.