### PR TITLE
Added Support for Direct MUI Icon Usage

### DIFF
--- a/src/components/CustomDropdown/CustomDropdown.jsx
+++ b/src/components/CustomDropdown/CustomDropdown.jsx
@@ -74,6 +74,11 @@ class CustomDropdown extends React.Component {
       case "function":
         icon = <this.props.buttonIcon className={classes.buttonIcon} />;
         break;
+      case "object":
+        if (buttonIcon.type.muiName === "Icon") {
+          icon = this.props.buttonIcon;
+        }
+        break;
       case "string":
         icon = (
           <Icon className={classes.buttonIcon}>{this.props.buttonIcon}</Icon>
@@ -189,7 +194,7 @@ CustomDropdown.propTypes = {
     "rose"
   ]),
   buttonText: PropTypes.node,
-  buttonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  buttonIcon: PropTypes.oneOfType([PropTypes.func, PropTypes.object, PropTypes.string]),
   dropdownList: PropTypes.array,
   buttonProps: PropTypes.object,
   dropup: PropTypes.bool,


### PR DESCRIPTION
This adds the ability for a Material UI Icon to be passed directly to the button. This allows Font-Awesome Icons to be used as the icon of the top level of the custom dropdown.

Additional valid buttonIcon values would now include the following formats:
`<Icon className={clsx(classes.icon, 'fas fa-shopping-cart')} />`
OR
`<Icon className={classes.icon + ' fas fa-shopping-cart'} />`