### PR TITLE
Fix a pagination component's variable typo

### DIFF
--- a/src/components/Pagination/Pagination.js
+++ b/src/components/Pagination/Pagination.js
@@ -25,8 +25,8 @@ export default function Pagination(props) {
         });
         return (
           <li className={classes.paginationItem} key={key}>
-            {prop.onClick !== undefined ? (
-              <Button onClick={prop.onClick} className={paginationLink}>
+            {props.onClick !== undefined ? (
+              <Button onClick={props.onClick} className={paginationLink}>
                 {prop.text}
               </Button>
             ) : (


### PR DESCRIPTION
Thank you for your builds, and It really helps me.

Implementing some stuff, I found A 's' in Props was missing on the Pagination component, so fixed.

The fix actually is not a big deal, but I'm sending a PR.

